### PR TITLE
Xpdf rc path Compatibility with Code Freezing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![Python package](https://github.com/ashutoshvarma/pyxpdf_data/workflows/Python%20package/badge.svg)
-![PyPI](https://img.shields.io/pypi/v/pyxpdf_data)
+[![Python package](https://github.com/ashutoshvarma/pyxpdf_data/workflows/Python%20package/badge.svg)](https://github.com/ashutoshvarma/pyxpdf_data/actions)
+[![PyPI](https://img.shields.io/pypi/v/pyxpdf_data)](https://pypi.org/project/pyxpdf-data/)
 
 # pyxpdf_data
 This python package consists of encoding files for use with [pyxpdf](https://github.com/ashutoshvarma/pyxpdf).

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pip install pyxpdf_data
 I would love to ship them with pyxpdf but some of these files have different license
 than pyxpdf so we have to distribute them seprately.
 
+
 ## License
 While pyxpdf is licensed under the GPL, these encoding files have different 
 license,  and thus distributed separately.
@@ -28,4 +29,20 @@ Verbatim copies of the Ghostscript project's licensing info are included with th
 package see fonts/COPYING.affero
 
 The rest of module is licensed under MIT.
+
+
+## Changelog
+
+### v1.1.0 (04/08/2020)
+- remove default settings for pyxpdf (now resides in pyxpdf itself)
+- add option to disable rewriting of xpdfrc in `get_xpdfrc()`
+- add 35 Postscript base fonts from ghostscript
+
+### v1.0.1 (31/03/2020)
+- Fix `xpdfrc` path not readable when installed in system site package
+
+### v1.0 (20/03/2020)
+- Initial Version
+
+
 

--- a/pyxpdf_data/__init__.py
+++ b/pyxpdf_data/__init__.py
@@ -1,13 +1,15 @@
 import os
 import time
-from distutils.sysconfig import get_python_lib
 from pathlib import Path
+from hashlib import md5
+from appdirs import AppDirs
 
 from .encodings import _get_encodings_block
 from .fonts import _get_fonts_block, get_fonts
 from .utils import POPPLER_DATA_DIR
 
 __version__ = "1.1.0"
+PYXPDF_RC_PATH = "PYXPDF_RC_PATH"
 
 
 def _xpdfrc_header():
@@ -32,6 +34,25 @@ def generate_xpdfrc():
 def get_poppler_dir():
     return str(POPPLER_DATA_DIR)
 
+    
+def get_xpdfrc_path():
+    """
+    Get the path of xpdfrc file.
+
+    First try to get the path from an environment variable named `PYXPDF_RC_PATH`.
+    If the variable does not exist, fall back to the user application  data directory
+    using appdirs package.
+    """
+    if PYXPDF_RC_PATH in os.environ:
+        xpdf_rc_path = Path(os.environ[PYXPDF_RC_PATH])
+    else:
+        pyxpdf_user_data_dir = AppDirs("pyxpdf", version=__version__).user_config_dir
+        # Make sure that this config file is unique to this instance as multiple pyxpdf_data installations
+        # may exist in one system (i.e. virtual environments and/or freezed applications).
+        data_path_hash = md5(str(POPPLER_DATA_DIR.resolve()).encode('utf-8')).hexdigest()
+        xpdf_rc_path = Path(pyxpdf_user_data_dir).joinpath(data_path_hash, "default.xpdf")
+    return xpdf_rc_path
+
 
 def get_xpdfrc(force_rewrite=True):
     """
@@ -43,12 +64,13 @@ def get_xpdfrc(force_rewrite=True):
         generate xpdfrc again even if it exists already. Helpful if somehow xpdfrc file
         got corrupted.
     """
-    xpdfrc_path = Path(get_python_lib(), "default.xpdf")
+    xpdfrc_path = get_xpdfrc_path()
     if (not xpdfrc_path.exists()) or force_rewrite:
         xpdfrc = generate_xpdfrc()
+        xpdfrc_path.parent.mkdir(parents=True, exist_ok=True)
         with open(str(xpdfrc_path), "w") as fp:
             fp.write(xpdfrc)
-    return str(xpdfrc_path.absolute())
+    return str(xpdfrc_path.absolute().resolve())
 
 
 __all__ = [get_fonts, get_xpdfrc, get_poppler_dir, generate_xpdfrc]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     author_email="ashutoshvarma11@live.com",
     url="https://github.com/ashutoshvarma/pyxpdf_data",
     license="MIT",
+    install_requires=["appdirs",],
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.4",


### PR DESCRIPTION
Hi @ashutoshvarma 

## Changes

This PR makes generating xpdf_rc file path dynamic. The path is obtained using one of two methods:
1. Environment variables (highest priority): if there is an environment variable  named *PYXPDF_RC_PATH* it will be used.
2. Using the **appdirs** package, we generate the file inside the Os specific user application config path taking care of returning a unique path per each instance (installation) of the pyxpdf_data package using a **md5**  hash of the poppler data path.

## Rationale

The changes proposed in this PR are required to make the package compatible with code **freezing** tools such as *PyInstaller* as these tools disregard the site-packages directory, and package the stdlib as a zip file.

Best Regards,
